### PR TITLE
Added export ignores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Fixes #16

A fix quoted directly from the Godot Documentation.

<img width="1025" height="485" alt="image" src="https://github.com/user-attachments/assets/f329a2d1-ec55-429c-9ac1-b8b015551836" />

I've been using your plugin a lot and I love it, but it's really annoying having to clean the excess files every time I install it. So here's a fix that I found in Godot's official documentation.

Read the docs [here](https://docs.godotengine.org/en/latest/community/asset_library/submitting_to_assetlib.html#recommendations)